### PR TITLE
Fix NaN when applying acos on double numbers greater than 1.0

### DIFF
--- a/src/main/java/wiadrodanych/utils/GeoTools.java
+++ b/src/main/java/wiadrodanych/utils/GeoTools.java
@@ -9,6 +9,8 @@ public class GeoTools {
         } else {
             double theta = lon1 - lon2;
             double dist = Math.sin(Math.toRadians(lat1)) * Math.sin(Math.toRadians(lat2)) + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) * Math.cos(Math.toRadians(theta));
+            if (dist > 1.0)
+                dist = 1.0;
             dist = Math.acos(dist);
             dist = Math.toDegrees(dist);
             dist = dist * 60 * 1.1515;


### PR DESCRIPTION
I've noticed problem with computing distance with given formula:
https://github.com/zorteran/wiadro-danych-kafka-streams/blob/master/src/main/java/wiadrodanych/utils/GeoTools.java#L11-L12

```Java
double dist = Math.sin(Math.toRadians(lat1)) * Math.sin(Math.toRadians(lat2)) + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) * Math.cos(Math.toRadians(theta));
dist = Math.acos(dist);
```
Because of inaccuracy of `double` type there may be a situation when `dist` will be initialized with number greater than `1.0` and applying function `Math.acos` on such number will return `NaN`.